### PR TITLE
Simplify install

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,14 @@ $ source jupytermp/bin/activate
 (jupytermp) $
 ```
 
+If running windows, the commmand would be
+
+``` console
+c:\Temp> python3 -m venv jupytermp
+c:\Temp> myenv\Scripts\activate jupytermp\activate
+(myenv) C:\Temp>
+```
+
 Install this package using pip
 
 ``` console

--- a/README.md
+++ b/README.md
@@ -9,74 +9,39 @@ Create and activate a virtualenv
 ``` console
 $ python3 -m venv jupytermp
 $ source jupytermp/bin/activate
+(jupytermp) $
 ```
 
 Install this package using pip
 
 ``` console
-$ pip install https://github.com/dwighthubbard/jupyter_micropython_kernel/zipball/master
+(jupytermp) $ pip install https://github.com/dwighthubbard/jupyter_micropython_kernel/zipball/master
+...
+Installing collected packages: wcwidth, six, prompt-toolkit, pyzmq, decorator, ipython-genutils, traitlets, jupyter-core, python-dateutil, tornado, jupyter-client, ptyprocess, pexpect, pickleshare, simplegeneric, backcall, parso, jedi, pygments, ipython, ipykernel, jupyter-console, jsonschema, nbformat, pandocfilters, entrypoints, testpath, webencodings, html5lib, bleach, mistune, MarkupSafe, jinja2, nbconvert, terminado, Send2Trash, notebook, qtconsole, widgetsnbextension, ipywidgets, jupyter, pyserial, jupyter-micropython-kernel
+  Running setup.py install for tornado ... done
+  Running setup.py install for simplegeneric ... done
+  Running setup.py install for backcall ... done
+  Running setup.py install for pandocfilters ... done
+  Running setup.py install for MarkupSafe ... done
+  Running setup.py install for jupyter-micropython-kernel ... done
+Successfully installed MarkupSafe-1.0 Send2Trash-1.5.0 backcall-0.1.0 bleach-2.1.3 decorator-4.3.0 entrypoints-0.2.3 html5lib-1.0.1 ipykernel-4.8.2 ipython-6.4.0 ipython-genutils-0.2.0 ipywidgets-7.2.1 jedi-0.12.0 jinja2-2.10 jsonschema-2.6.0 jupyter-1.0.0 jupyter-client-5.2.3 jupyter-console-5.2.0 jupyter-core-4.4.0 jupyter-micropython-kernel-0.1.1 mistune-0.8.3 nbconvert-5.3.1 nbformat-4.4.0 notebook-5.5.0 pandocfilters-1.4.2 parso-0.2.1 pexpect-4.6.0 pickleshare-0.7.4 prompt-toolkit-1.0.15 ptyprocess-0.5.2 pygments-2.2.0 pyserial-3.4 python-dateutil-2.7.3 pyzmq-17.0.0 qtconsole-4.3.1 simplegeneric-0.8.1 six-1.11.0 terminado-0.8.1 testpath-0.3.1 tornado-5.0.2 traitlets-4.3.2 wcwidth-0.1.7 webencodings-0.5.1 widgetsnbextension-3.2.1
+(jupytermp) $
 ```
 
 Install the jupyter kernel
 
 ``` console
-(mpnotebook) dhubbard@littlepython:~/git/jupyter_micropython_kernel$ python -m jupyter_micropython_kernel.install
+(jupytermp) $ python -m jupyter_micropython_kernel.install
 DEBUG:__main__:Putting kernel in virtualenv share directory '/tmp/mpnotebook/share/jupyter'
 INFO:__main__:Writing jupyter kernel to '/tmp/mpnotebook/share/jupyter/kernels/micropython/kernel.json'
-$
+(jupytermp) $
 ```
-First install Jupyter: http://jupyter.org/install.html
 
-Then clone this repository and install the setup.py (assuming python 3.0, be
-sure to use the same version of python as Jupyter is installed with):
+Now run Jupyter notebook:
 
-    python3 setup.py install
-
-On Mac OSX and some Linux flavors you might need to run as root with sudo for
-the above command.  Make sure the installation completes successfully and that
-you do not see any error messages.
-
-Finally create a Jupyter kernel specification for the serial port and baud rate
-of your MicroPython board.  Unfortunately there is no UI or ability to pick the
-serial port/baud from the notebook so you'll have to bake this in to a kernel
-configuration.
-
-From the Jupyter kernel docs find your user specific Jupyter kernel spec location: http://jupyter-client.readthedocs.io/en/latest/kernels.html#kernel-specs  You want the **user** location:
-
-*   Windows: %APPDATA%\jupyter\kernels (note if you aren't sure where this is located see: http://www.pcworld.com/article/2690709/windows/whats-in-the-hidden-windows-appdata-folder-and-how-to-find-it-if-you-need-it.html)
-*   macOS: ~/Library/Jupyter/kernels
-*   Linux: ~/.local/share/jupyter/kernels
-
-Create the above kernels folder if it doesn't already exist. Then inside the
-kernels folder create a new folder called 'micropython' and copy the included
-kernel.json file inside it.
-
-Open the copied kernel.json file and edit it so the 4th line:
-
-    "/dev/tty.SLAB_USBtoUART", "115200",
-
-Is the serial name and baud rate of your MicroPython board.  For example if using COM4 and 115200 baud you would change it to:
-
-    "COM4", "115200",
-
-Also change the display name of the kernel on line 6:
-
-    "display_name": "MicroPython - /dev/tty.SLAB_USBtoUART",
-
-Set a value that describes your board, like:
-
-    "display_name": "MicroPython - COM4",
-
-This is the name you will see in Jupyter's notebook UI when picking the kernel
-to start.  You don't need to change any other config in the kernel.json.  Be
-very careful to make sure all the commands, double quotes, etc. are present
-(this needs to be a valid JSON formatted file).
-
-At this point you should have the following file: (Jupyter kernel spec location above)/micropython/kernel.json
-
-Now run Jupyter notebooks:
-
-    jupyter notebook
+``` console
+(jupytermp) $ jupyter notebook
+```
 
 In the notebook click the New button in the upper right, you should see your
 MicroPython kernel display name listed.  Click it to create a notebook using

--- a/README.md
+++ b/README.md
@@ -4,6 +4,27 @@ Jupyter kernel to interact with a MicroPython or CircuitPython board over its se
 
 ## Installation
 
+Create and activate a virtualenv
+
+``` console
+$ python3 -m venv jupytermp
+$ source jupytermp/bin/activate
+```
+
+Install this package using pip
+
+``` console
+$ pip install https://github.com/dwighthubbard/jupyter_micropython_kernel/zipball/master
+```
+
+Install the jupyter kernel
+
+``` console
+(mpnotebook) dhubbard@littlepython:~/git/jupyter_micropython_kernel$ python -m jupyter_micropython_kernel.install
+DEBUG:__main__:Putting kernel in virtualenv share directory '/tmp/mpnotebook/share/jupyter'
+INFO:__main__:Writing jupyter kernel to '/tmp/mpnotebook/share/jupyter/kernels/micropython/kernel.json'
+$
+```
 First install Jupyter: http://jupyter.org/install.html
 
 Then clone this repository and install the setup.py (assuming python 3.0, be

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ $ source jupytermp/bin/activate
 Install this package using pip
 
 ``` console
-(jupytermp) $ pip install https://github.com/dwighthubbard/jupyter_micropython_kernel/zipball/master
+(jupytermp) $ pip install https://github.com/adafruit/jupyter_micropython_kernel/zipball/master
 ...
 Installing collected packages: wcwidth, six, prompt-toolkit, pyzmq, decorator, ipython-genutils, traitlets, jupyter-core, python-dateutil, tornado, jupyter-client, ptyprocess, pexpect, pickleshare, simplegeneric, backcall, parso, jedi, pygments, ipython, ipykernel, jupyter-console, jsonschema, nbformat, pandocfilters, entrypoints, testpath, webencodings, html5lib, bleach, mistune, MarkupSafe, jinja2, nbconvert, terminado, Send2Trash, notebook, qtconsole, widgetsnbextension, ipywidgets, jupyter, pyserial, jupyter-micropython-kernel
   Running setup.py install for tornado ... done

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ $ source jupytermp/bin/activate
 If running windows, the commmand would be
 
 ``` console
-c:\Temp> python3 -m venv jupytermp
+c:\Temp> python -m venv jupytermp
 c:\Temp> myenv\Scripts\activate jupytermp\activate
 (myenv) C:\Temp>
 ```

--- a/jupyter_micropython_kernel/install.py
+++ b/jupyter_micropython_kernel/install.py
@@ -19,6 +19,7 @@ kernel_config = {
 }
 
 
+
 def jupyter_data_directories():
     jupyter_command = os.path.join(os.path.dirname(sys.executable), 'jupyter')
     directories = []

--- a/jupyter_micropython_kernel/install.py
+++ b/jupyter_micropython_kernel/install.py
@@ -1,0 +1,69 @@
+"""
+Install the jupyter micropython kernel configuration for this module
+"""
+import json
+import logging
+import os
+import platform
+import subprocess
+import sys
+
+
+logger = logging.getLogger(__name__)
+
+
+kernel_config = {
+    "argv": ["python3", "-m", "jupyter_micropython_kernel", "search", "115200", "-f", "{connection_file}"],
+    "display_name": "MicroPython - Serial",
+    "language": "micropython"
+}
+
+
+def jupyter_data_directories():
+    jupyter_command = os.path.join(os.path.dirname(sys.executable), 'jupyter')
+    directories = []
+    with subprocess.Popen([jupyter_command, '--paths'], stdout=subprocess.PIPE) as proc:
+        in_data = False
+        for line in proc.stdout.readlines():
+            line = line.decode()
+            if not line[0].isspace():
+                if line.startswith('data:'):
+                    in_data = True
+                else:
+                    in_data = False
+                continue
+            if not in_data:
+                continue
+            directories.append(line.strip())
+    return directories
+
+
+def jupyter_data_directory():
+    # Get all config directories
+    possible_data_directories = jupyter_data_directories()
+
+    # If running in a virtualenv default to the venv config directory
+    venv_dir = os.environ.get('VIRTUAL_ENV', None)
+    if venv_dir:
+        venv_data_dir = os.path.join(venv_dir, 'share/jupyter')
+        if venv_data_dir in possible_data_directories:
+            logger.debug('Putting kernel in virtualenv share directory %r', venv_data_dir)
+            return venv_data_dir
+
+    return possible_data_directories[0]
+
+
+def install_kernel():
+    kernel_config_directory = os.path.join(jupyter_data_directory(), 'kernels/micropython')
+    kernel_config_filename = os.path.join(kernel_config_directory, 'kernel.json')
+    if not os.path.exists(kernel_config_directory):
+        os.makedirs(kernel_config_directory)
+
+    logger.info('Writing jupyter kernel to %r', kernel_config_filename)
+    with open(kernel_config_filename, 'w') as fh:
+        json.dump(kernel_config, fh, indent=4, sort_keys=True)
+
+
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.DEBUG)
+    install_kernel()

--- a/jupyter_micropython_kernel/kernel.py
+++ b/jupyter_micropython_kernel/kernel.py
@@ -2,7 +2,9 @@ import logging
 
 from ipykernel.kernelbase import Kernel
 import glob
+import platform
 import pkg_resources
+import serial.tools.list_ports
 
 from jupyter_micropython_kernel.pyboard import Pyboard
 
@@ -22,16 +24,19 @@ def make_micropython_kernel(port, baud):
     # and call its constructor to control how it's built).  As a workaround
     # we'll just build a separate kernel class with a class-specific port and
     # baud rate baked in.
-    DEVICEPATH=['/dev/ttyUSB[0-9]', '/dev/ttyACM[0-9]', '/dev/tty.SLAB_USBtoUART', 'COM[0-9]']
+    DEVICEPATH=['/dev/ttyUSB[0-9]', '/dev/ttyACM[0-9]', '/dev/tty.SLAB_USBtoUART', '/dev/cu.wchusbserial']
 
     if not port or port == 'search':
         logger.info('Searching for serial port')
-        for pattern in DEVICEPATH:
-            tty_files = glob.glob(pattern)
-            if tty_files:
-                logger.info('Found serial port %s', tty_files[0])
-                port = tty_files[0]
-                break
+        if platform.system() in ['Windows']:
+            port = serial.tools.list_ports.comports()[0]
+        else:
+            for pattern in DEVICEPATH:
+                tty_files = glob.glob(pattern)
+                if tty_files:
+                    logger.info('Found serial port %s', tty_files[0])
+                    port = tty_files[0]
+                    break
 
     class MicroPythonKernel(Kernel):
         implementation = 'micropython'

--- a/jupyter_micropython_kernel/kernel.py
+++ b/jupyter_micropython_kernel/kernel.py
@@ -1,6 +1,7 @@
 import logging
 
 from ipykernel.kernelbase import Kernel
+import glob
 import pkg_resources
 
 from jupyter_micropython_kernel.pyboard import Pyboard
@@ -21,6 +22,17 @@ def make_micropython_kernel(port, baud):
     # and call its constructor to control how it's built).  As a workaround
     # we'll just build a separate kernel class with a class-specific port and
     # baud rate baked in.
+    DEVICEPATH=['/dev/ttyUSB[0-9]', '/dev/ttyACM[0-9]', '/dev/tty.SLAB_USBtoUART', 'COM[0-9]']
+
+    if not port or port == 'search':
+        logger.info('Searching for serial port')
+        for pattern in DEVICEPATH:
+            tty_files = glob.glob(pattern)
+            if tty_files:
+                logger.info('Found serial port %s', tty_files[0])
+                port = tty_files[0]
+                break
+
     class MicroPythonKernel(Kernel):
         implementation = 'micropython'
         implementation_version = version

--- a/jupyter_micropython_kernel/kernel.py
+++ b/jupyter_micropython_kernel/kernel.py
@@ -29,7 +29,7 @@ def make_micropython_kernel(port, baud):
     if not port or port == 'search':
         logger.info('Searching for serial port')
         if platform.system() in ['Windows']:
-            port = serial.tools.list_ports.comports()[0]
+            port = serial.tools.list_ports.comports()[0].device
         else:
             for pattern in DEVICEPATH:
                 tty_files = glob.glob(pattern)

--- a/jupyter_micropython_kernel/pyboard.py
+++ b/jupyter_micropython_kernel/pyboard.py
@@ -38,7 +38,7 @@ Or:
     python pyboard.py test.py
 
 """
-
+import glob
 import sys
 import time
 

--- a/kernel.json
+++ b/kernel.json
@@ -1,8 +1,8 @@
 {
  "argv": ["python3",
           "-m", "jupyter_micropython_kernel",
-          "/dev/tty.SLAB_USBtoUART", "115200",
+          "search", "115200",
           "-f", "{connection_file}"],
- "display_name": "MicroPython - /dev/tty.SLAB_USBtoUART",
+ "display_name": "MicroPython",
  "language": "micropython"
 }

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,14 @@
 from setuptools import setup
 
 setup(name='jupyter_micropython_kernel',
-      version='0.1.0',
+      version='0.1.1',
       description='External MicroPython kernel for Jupyter notebooks.',
       author='Tony DiCola',
       author_email='tdicola@adafruit.com',
       url='https://github.com/adafruit/jupyter_micropython_kernel',
       packages=['jupyter_micropython_kernel'],
-      install_requires=['pyserial']
-     )
+      install_requires=[
+            'jupyter',
+            'pyserial'
+      ]
+)

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='jupyter_micropython_kernel',
-      version='0.1.1',
+      version='0.1.2',
       description='External MicroPython kernel for Jupyter notebooks.',
       author='Tony DiCola',
       author_email='tdicola@adafruit.com',


### PR DESCRIPTION
This adds an install module that should install the kernel.json into the correct location.  

It prefers installation inside a virtualenv since it avoids sudo issues and can easily be removed without causing issues with other jupyter notebook installations.

If a virtualenv is not present it will run jupyter --paths to get the paths for the jupyter command in the same bin directory as the current python interpreter.
The jupyter kernel has been modified to accept a value of "search" for the tty device name, which will cause it to search for possible serial devices.  This is the default for the install command.

The install becomes 3 steps:

1. Create virtualenv 
2. Install this package via pip
3. Run "python -m jupyter_micropython_kernel.install" to install the kernel.json
